### PR TITLE
Made the landing page background adjust to every screen size.

### DIFF
--- a/frontend/quiz-app/src/Styles/HomePage.css
+++ b/frontend/quiz-app/src/Styles/HomePage.css
@@ -3,15 +3,25 @@
 body {
   margin: 0;
   padding: 0;
+  
 }
 
 .quiz-homepage {
   background: linear-gradient(135deg, #ddffe7 60%, cyan);
-  height: 100vh;
+  /* height: 100vh;   */ 
+  /* changes made to adapt screen size */
+  min-height:100vh;
+  width: 100%;
+  background-size: cover;
+  background-position: center center;
+
 }
 
 .quiz-navbar-container {
   width: 100%;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
 }
 
 .quiz-navbar-heading {
@@ -81,7 +91,12 @@ body {
 }
 
 .quiz-home-image {
-  width: 500px;
+  /* width: 500px;
   height: 500px;
+  border-radius: 50%; */
+  width: 100%;
+  max-width: 500px;
+  height: auto;
   border-radius: 50%;
+  
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "quizzie-app",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "quizzie-app",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}


### PR DESCRIPTION
Issue: There was a White space at bottom of the landing page. The size of white space was different for some screens and was good for others.

So i made the changes so that the background automatically gets adjusted to different screen-sizes.
Added min-height: 100vh and ensured layout stretches across all resolutions.